### PR TITLE
fix: 🐛 disable fix for a rule that has no implemented fixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ module.exports = {
         'z-index',
       ],
       {
+        'disableFix': true,
         'ignoreFunctions': true,
         'ignoreKeywords': {
           '': [


### PR DESCRIPTION
Disabling fix functionality until we implement a custom fixer. Currently it errors on the missing fix function when the `--fix` flag is used.