### PR TITLE
fix(CIRules): allow 1 as a z-index value without a variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,7 @@ module.exports = {
           ],
           'z-index': [
             -1,
+            1,
             'auto',
           ],
         },

--- a/tooling/cz-config.js
+++ b/tooling/cz-config.js
@@ -39,13 +39,13 @@ module.exports = {
 
   'scopes': [
     {
-      'name': 'CI Rules',
+      'name': 'CIRules',
     },
     {
-      'name': 'Dev Rules',
+      'name': 'DevRules',
     },
     {
-      'name': 'Spec Rules',
+      'name': 'SpecRules',
     },
     {
       'name': 'Build',


### PR DESCRIPTION
1 is often used locally to create a z-index context but has no semantic value

- allow z-index value `1`
- update scope declaration to pass format check